### PR TITLE
плейсхолдеры смарти

### DIFF
--- a/core/components/modxsmarty/smarty_plugins/function.ph.php
+++ b/core/components/modxsmarty/smarty_plugins/function.ph.php
@@ -15,6 +15,15 @@ function smarty_function_ph($params, & $smarty) {
         $assign = (string)$params['assign'];
     }
     $output = $smarty->modx->getPlaceholder($name);
+    
+    $modx = & $smarty->modx;
+    $modx->getParser();
+    
+    if(isset($params['parse']) && $params['parse'] == 'true'){
+    	$maxIterations= intval($modx->getOption('parser_max_iterations', $params, 10));
+    	$modx->parser->processElementTags('', $output, true, false, '[[', ']]', array(), $maxIterations);
+    	$modx->parser->processElementTags('', $output, true, true, '[[', ']]', array(), $maxIterations);
+    }   
 
     return !empty($assign) ? $smarty->assign($assign, $output) : $output;
 }


### PR DESCRIPTION
добавлена обработка modx-тегов в плейсхолдерах смарти. а то в ридми поддержка заявлена, а фактически парсинг отсутствовал :)
